### PR TITLE
[FEAT]초기 엔티티 설정과 더미데이터 세팅 #5

### DIFF
--- a/src/main/java/com/project/always/domain/BaseEntity.java
+++ b/src/main/java/com/project/always/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.project.always.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @DateTimeFormat
+    private LocalDateTime localDateTime;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDateTime;
+}

--- a/src/main/java/com/project/always/domain/bar/Bar.java
+++ b/src/main/java/com/project/always/domain/bar/Bar.java
@@ -1,0 +1,32 @@
+package com.project.always.domain.bar;
+
+import com.project.always.domain.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bar extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bar_id")
+    private Long id;
+
+    private String title;
+
+    private String location;
+
+    private String tel;
+
+    private String lat;
+    private String log;
+
+}

--- a/src/main/java/com/project/always/domain/bar/BarRepository.java
+++ b/src/main/java/com/project/always/domain/bar/BarRepository.java
@@ -1,0 +1,7 @@
+package com.project.always.domain.bar;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BarRepository extends JpaRepository<Bar, Long> { // type, id
+
+}

--- a/src/main/java/com/project/always/domain/member/Member.java
+++ b/src/main/java/com/project/always/domain/member/Member.java
@@ -1,0 +1,45 @@
+package com.project.always.domain.member;
+
+import com.project.always.domain.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(length = 50, nullable = false, unique = true)
+    private String email;
+
+
+    @Column(length = 20, nullable = false)
+    private String password;
+
+    @Column(length = 20, nullable = false)
+    private String name;
+
+//    @Embedded
+//    private ProfileUrl profileUrl;
+
+    @Builder
+    private Member(final String email, final String password, final String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/project/always/domain/member/MemberRepository.java
+++ b/src/main/java/com/project/always/domain/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.project.always.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> { // type, id
+
+}

--- a/src/main/java/com/project/always/domain/member/ProfileUrl.java
+++ b/src/main/java/com/project/always/domain/member/ProfileUrl.java
@@ -1,0 +1,12 @@
+package com.project.always.domain.member;
+
+import javax.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class ProfileUrl {
+
+}

--- a/src/main/java/com/project/always/domain/surbey/Survey.java
+++ b/src/main/java/com/project/always/domain/surbey/Survey.java
@@ -1,0 +1,28 @@
+package com.project.always.domain.surbey;
+
+import com.project.always.domain.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Survey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "survey_id")
+    private Long id;
+
+    private String questionText;
+
+    private String option1;
+
+    private String option2;
+}

--- a/src/main/java/com/project/always/domain/surbey/SurveyRepository.java
+++ b/src/main/java/com/project/always/domain/surbey/SurveyRepository.java
@@ -1,0 +1,7 @@
+package com.project.always.domain.surbey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,24 @@
+# mysql
+spring.datasource.url=jdbc:mysql://localhost:3306/AlwaysDB?characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# sql console
+spring.jpa.show-sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# hibernate setting
+spring.jpa.database=mysql
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.generate-ddl=true
+# spring.jpa.properties.hibernate.format_sql=true  // sql log result
+
+# logging
+logging.level.org.hibernate.type.descriptor.sql=trace
+logging.level.org.hibernate.SQL=DEBUG
+
+# schema.sql
+spring.sql.init.mode=always
+# script file hibernate init
+spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS member;
+
+create table member
+(
+    member_id           bigint      not null auto_increment primary key,
+    email        varchar(50) not null,
+    password     varchar(20) not null,
+    name varchar(20) null
+
+);
+
+insert into member (member_id, email, password, name)
+values (1, "test@naver.com", "test1234", "testId");

--- a/src/test/java/com/project/always/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/com/project/always/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.project.always.domain.member;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("회원 DB 조회")
+    @Test
+    void memberInfoReader() throws Exception{
+        //given
+        Member member = Member.builder()
+                .email("cobi@naver.com")
+                .password("cobi1234")
+                .name("cobi")
+                .build();
+        memberRepository.save(member);
+
+        //when
+        List<Member> memberList = memberRepository.findAll();
+
+        //then
+        Assertions.assertThat(memberList).hasSize(2)
+                .extracting("email","password","name")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("test@naver.com", "test1234", "testId"),
+                        Tuple.tuple("cobi@naver.com", "cobi1234", "cobi")
+                );
+
+    }
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 초기 엔티티(회원,술집,설문지) 간단하게 생성하였습니다.
- schema.sql, jpa, db 환경설정 마쳤습니다.
- db 연동 테스트하였습니다.
<img width="500" alt="db" src="https://github.com/Al-ways/Al-ways-BE/assets/91714677/7da9e9fa-f9a3-405d-ae3d-cee2c89f62f2">

## 📎 Issue 번호
closed #5 