### PR TITLE
[FEAT] Swagger, RestDocs 세팅 (#10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
-//querydsl 추가
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 buildscript {
+	//querydsl 추가
 	dependencies {
 		classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:1.0.10")
+	}
+	//restdocsapi add
+	ext {
+		restdocsApiSpecVersion = '0.16.2'
 	}
 }
 
@@ -10,12 +17,15 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.15'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-	// rest docs
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+
+	id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
+
+	// swagger generator 플러그인 추가
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
-//querydsl
-apply plugin: "com.ewerk.gradle.plugins.querydsl"
+////querydsl
+//apply plugin: "com.ewerk.gradle.plugins.querydsl"
 
 group = 'com.project'
 version = '0.0.1-SNAPSHOT'
@@ -24,22 +34,31 @@ java {
 	sourceCompatibility = '11'
 }
 
+openapi3 {
+	setServer("http://localhost:8080")
+	title = "Al-ways API 문서"
+	description = "Spring REST Docs with SwaggerUI."
+	version = "0.0.1"
+	format = "yaml"
+}
+
+// swaggerSources 설정 추가
+swaggerSources {
+	sample {
+		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+	}
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
-	// rest docs
-	asciidoctorExt
 }
 
 repositories {
 	mavenCentral()
 }
 
-// rest docs : snippetsDir
-ext {
-	set('snippetsDir', file("build/generated-snippets"))
-}
 
 dependencies {
 	// spring boot
@@ -62,29 +81,51 @@ dependencies {
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// RestDocs
-	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	//Rest Assured
+	testImplementation 'io.rest-assured:rest-assured'
+
+	//Rest Docs
+	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+	testImplementation "com.epages:restdocs-api-spec-restassured:${restdocsApiSpecVersion}"
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
+
+	// SwaggerUI
+	swaggerUI 'org.webjars:swagger-ui:4.11.1'
 
 	// jwt
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	// querydsl
-	implementation 'com.querydsl:querydsl-jpa'
-	implementation 'com.querydsl:querydsl-apt'
+//	// querydsl
+//	implementation 'com.querydsl:querydsl-jpa'
+//	implementation 'com.querydsl:querydsl-apt'
+}
+
+// GenerateSwaggerUI 태스크가, openapi3 task 를 의존하도록 설정
+tasks.withType(GenerateSwaggerUI) {
+	dependsOn 'openapi3'
+}
+
+// 생성된 SwaggerUI 를 jar 에 포함시키기 위해 build/resources 경로로 로 복사
+tasks.register('copySwaggerUI', Copy) {
+	dependsOn 'generateSwaggerUISample'
+
+	def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+
+	from("${generateSwaggerUISampleTask.outputDir}")
+	into("${project.buildDir}/resources/main/static/docs")
+}
+
+// bootJar 실행 전, copySwaggerUI 를 실행하도록 설정
+tasks.withType(BootJar) {
+	dependsOn 'copySwaggerUI'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
 	useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
-}
-
-// rest docs 설정 보류 swagger 처리
 
 //setup asciidoctor
 //asciidoctor {
@@ -108,25 +149,25 @@ tasks.named('asciidoctor') {
 
 //querydsl 추가
 //def querydslDir = 'src/main/generated'
-def querydslDir = "$buildDir/generated/querydsl"
-querydsl {
-	library = "com.querydsl:querydsl-apt"
-	jpa = true
-	querydslSourcesDir = querydslDir
-}
-
-sourceSets {
-	main {
-		java {
-			srcDirs = ['src/main/java', querydslDir]
-		}
-	}
-}
-
-compileQuerydsl{
-	options.annotationProcessorPath = configurations.querydsl
-}
-
-configurations {
-	querydsl.extendsFrom compileClasspath
-}
+//def querydslDir = "$buildDir/generated/querydsl"
+//querydsl {
+//	library = "com.querydsl:querydsl-apt"
+//	jpa = true
+//	querydslSourcesDir = querydslDir
+//}
+//
+//sourceSets {
+//	main {
+//		java {
+//			srcDirs = ['src/main/java', querydslDir]
+//		}
+//	}
+//}
+//
+//compileQuerydsl{
+//	options.annotationProcessorPath = configurations.querydsl
+//}
+//
+//configurations {
+//	querydsl.extendsFrom compileClasspath
+//}

--- a/src/main/java/com/project/always/controller/api/SampleControllerApi.java
+++ b/src/main/java/com/project/always/controller/api/SampleControllerApi.java
@@ -1,0 +1,23 @@
+package com.project.always.controller.api;
+
+import com.project.always.controller.api.request.SampleRequest;
+import com.project.always.controller.api.response.SampleResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SampleControllerApi {
+
+    @PostMapping("/api/users")
+    @ResponseStatus(HttpStatus.OK)
+    public SampleResponse returnNameAndAge(@RequestBody SampleRequest sampleRequest) {
+        return new SampleResponse(sampleRequest.getName(), sampleRequest.getAge());
+    }
+}
+
+

--- a/src/main/java/com/project/always/controller/api/request/SampleRequest.java
+++ b/src/main/java/com/project/always/controller/api/request/SampleRequest.java
@@ -1,0 +1,23 @@
+package com.project.always.controller.api.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class SampleRequest {
+    private String name;
+    private int age;
+
+    public SampleRequest() {
+    }
+
+    public SampleRequest(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+}

--- a/src/main/java/com/project/always/controller/api/response/SampleResponse.java
+++ b/src/main/java/com/project/always/controller/api/response/SampleResponse.java
@@ -1,0 +1,22 @@
+package com.project.always.controller.api.response;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class SampleResponse {
+    private String name;
+    private int age;
+
+
+    public SampleResponse() {
+    }
+
+    public SampleResponse(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+}

--- a/src/test/java/com/project/always/controller/api/BaseControllerTest.java
+++ b/src/test/java/com/project/always/controller/api/BaseControllerTest.java
@@ -1,0 +1,48 @@
+package com.project.always.controller.api;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@AutoConfigureRestDocs
+public abstract class BaseControllerTest {
+
+    protected static final String DEFAULT_RESTDOC_PATH = "{class_name}/{method_name}/";
+
+    protected RequestSpecification spec;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
+        this.spec = new RequestSpecBuilder()
+                .setPort(port)
+                .addFilter(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
+
+}

--- a/src/test/java/com/project/always/controller/api/SampleControllerApiTest.java
+++ b/src/test/java/com/project/always/controller/api/SampleControllerApiTest.java
@@ -1,0 +1,55 @@
+package com.project.always.controller.api;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+import net.minidev.json.JSONObject;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+class SampleControllerApiTest extends BaseControllerTest {
+
+    private static final Snippet REQUEST_FIELDS = requestFields(
+            fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+            fieldWithPath("age").type(JsonFieldType.NUMBER).description("나이")
+    );
+
+    private static final Snippet RESPONSE_FIELDS = requestFields(
+            fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+            fieldWithPath("age").type(JsonFieldType.NUMBER).description("나이")
+    );
+
+
+    @Test
+    void users_success_test() {
+        String expectedName = "jay";
+        int expectedAge = 27;
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("name", expectedName);
+        requestBody.put("age", expectedAge);
+
+        given(this.spec)
+                .filter(document(DEFAULT_RESTDOC_PATH, REQUEST_FIELDS, RESPONSE_FIELDS)) // API 문서 관련 필터 추가
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .body(requestBody)
+                .log().all()
+
+                .when()
+                    .post("/api/users")
+
+                .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("name", Matchers.equalTo(expectedName))
+                    .body("age", Matchers.equalTo(expectedAge));
+
+
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- 불필요한 restdocs 설정 제거
- openapi3 스펙 설정
- Swagger build 추가
- 유저 조회 API 테스트

## ETC
### SnippetException 이슈
   - Java 17 record 클래스와 Java 11 버전의 차이로 JSON 데이터와 Java 객체 간의 매핑 문제 해결

## 📎 Issue 번호
closed #10 